### PR TITLE
Fix: ros_upgrader.py not executable

### DIFF
--- a/ros_upgrader.py
+++ b/ros_upgrader.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import copy
 import fnmatch


### PR DESCRIPTION
# Issue
`ros_upgrader.py`:
-  is not executable.
- causes runtime error:
   ```
   ./ros_upgrader.py: line 3: import: command not found
   ./ros_upgrader.py: line 4: import: command not found
   ./ros_upgrader.py: line 5: import: command not found
   :
   ```
